### PR TITLE
Add asset settings modifiers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,30 @@ MaterializePlugin::new(TomlMaterialDeserializer) // type: MaterializePlugin<...,
     .with_processor(MyProcessor) // type: MaterializePlugin<..., MyProcessor<AssetLoadingProcessor<()>>>
 ```
 
+## Asset Settings Modifiers
+
+Occasionally, specific fields should have overrides to their asset settings for usability.
+For example, non-color-maps in `StandardMaterial` need to be linear, not sRGB. This is part of the default modifiers in `GlobalAssetSettingsModifiers`.
+
+Here's how to register one yourself:
+
+```rust no_run
+use bevy::{prelude::*, image::{ImageLoaderSettings, ImageSampler}};
+use bevy_materialize::prelude::*;
+App::new()
+    .insert_generic_material_asset_settings_modifier(
+        AssetSettingsTarget::field::<StandardMaterial>("base_color_texture"),
+        |settings: &mut ImageLoaderSettings| settings.sampler = ImageSampler::nearest(),
+    )
+    // All base_color_textures loaded from StandardMaterial now use nearest neighbor filtering!
+;
+```
+
+Note that these stack, if you now insert one that also sets `base_color_texture`s to use a linear color space, it'll do both modifications!
+
+These modifiers are also the settings type on generic material asset loaders (the type is `AssetSettingsModifiers` to be specific),
+so you can modify specific settings per-load.
+
 # Supported Bevy Versions
 | Bevy | bevy_materialize |
 -|-

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -175,6 +175,7 @@ impl MaterialAnimation for NextAnimation {
 	}
 }
 
+// TODO: images loaded by this don't respect asset settings modifiers!
 /// Allows different image [`fields`](Self::fields) to cycle a list of images at a specified [`fps`](Self::fps).
 #[derive(Reflect, Debug, Clone)]
 pub struct ImagesAnimation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,10 @@ use bevy::prelude::*;
 #[cfg(feature = "bevy_pbr")]
 use generic_material::GenericMaterialApplied;
 use load::{
-	GenericMaterialLoader, asset::AssetLoadingProcessor, deserializer::MaterialDeserializer, processor::MaterialProcessor,
+	GenericMaterialLoader,
+	asset::{AssetLoadingProcessor, GlobalAssetSettingsModifiers},
+	deserializer::MaterialDeserializer,
+	processor::MaterialProcessor,
 	simple::SimpleGenericMaterialLoader,
 };
 use prelude::*;
@@ -47,19 +50,22 @@ impl<D: MaterialDeserializer, P: MaterialProcessor + Clone> Plugin for Materiali
 
 		let shorthands = GenericMaterialShorthands::default();
 		let property_registry = MaterialPropertyRegistry::default();
+		let global_settings = GlobalAssetSettingsModifiers::default();
 
 		#[rustfmt::skip]
 		app
 			.add_plugins(MaterializeMarkerPlugin)
 			.insert_resource(shorthands.clone())
 			.insert_resource(property_registry.clone())
+			.insert_resource(global_settings.clone())
 			.register_type::<GenericMaterial3d>()
 			.init_asset::<GenericMaterial>()
-			.register_generic_material_sub_asset_image_settings_passthrough::<GenericMaterial>()
+			.register_generic_material_sub_asset::<GenericMaterial>()
 			.register_asset_loader(GenericMaterialLoader {
 				type_registry,
 				shorthands,
 				property_registry,
+				global_settings,
 				deserializer: self.deserializer.clone(),
 				do_text_replacements: self.do_text_replacements,
 				processor: self.processor.clone(),
@@ -71,7 +77,7 @@ impl<D: MaterialDeserializer, P: MaterialProcessor + Clone> Plugin for Materiali
 		}
 
 		#[cfg(feature = "bevy_image")]
-		app.register_generic_material_sub_asset_image_settings_passthrough::<Image>();
+		app.register_generic_material_sub_asset::<Image>();
 
 		#[cfg(feature = "bevy_pbr")]
 		#[rustfmt::skip]

--- a/src/load/asset.rs
+++ b/src/load/asset.rs
@@ -1,13 +1,17 @@
-use std::any::TypeId;
+use std::{
+	any::TypeId,
+	sync::{Arc, RwLock},
+};
 
 #[cfg(feature = "bevy_image")]
 use bevy::image::ImageLoaderSettings;
 use bevy::{
-	asset::{AssetPath, ParseAssetPathError, io::AssetSourceId},
+	asset::{AssetPath, Deferred, NestedLoader, ParseAssetPathError, StaticTyped, io::AssetSourceId, meta::Settings},
+	platform::collections::HashMap,
 	prelude::*,
 	reflect::{TypeRegistration, TypeRegistry},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::processor::{MaterialProcessor, MaterialProcessorContext};
 
@@ -56,45 +60,55 @@ pub trait GenericMaterialSubAssetAppExt {
 	/// Specifically, it allows loading of [`Handle<A>`] by simply providing a path relative to the material's directory.
 	fn register_generic_material_sub_asset<A: Asset>(&mut self) -> &mut Self;
 
-	/// Same as [`register_generic_material_sub_asset`](Self::register_generic_material_sub_asset), but passes image settings through.
-	/// This will cause an error if the asset loader doesn't use image settings.
-	fn register_generic_material_sub_asset_image_settings_passthrough<A: Asset>(&mut self) -> &mut Self;
+	/// Insert a modifier into [`GlobalAssetSettingsModifiers`].
+	/// # Examples
+	/// ```no_run
+	/// # use bevy::{prelude::*, image::{ImageLoaderSettings, ImageSampler}};
+	/// # use bevy_materialize::prelude::*;
+	/// App::new()
+	///     .insert_generic_material_asset_settings_modifier(
+	///         AssetSettingsTarget::field::<StandardMaterial>("base_color_texture"),
+	///         |settings: &mut ImageLoaderSettings| settings.sampler = ImageSampler::nearest(),
+	///     )
+	///     // All base_color_textures loaded from StandardMaterial now use nearest neighbor filtering!
+	/// # ;
+	/// ```
+	/// To see more about this system, visit [`AssetSettingsModifiers`] and/or see readme.
+	fn insert_generic_material_asset_settings_modifier<S: Settings>(
+		&mut self,
+		target: AssetSettingsTarget<'static>,
+		modifier: impl Fn(&mut S) + Clone + Send + Sync + 'static,
+	) -> &mut Self;
 }
-
-/// Reduces code duplication for the functions below.
-fn register_generic_material_sub_asset_internal<A: Asset>(app: &mut App, loader: ReflectGenericMaterialSubAsset) -> &mut App {
-	let mut type_registry = app.world().resource::<AppTypeRegistry>().write();
-	let registration = match type_registry.get_mut(TypeId::of::<Handle<A>>()) {
-		Some(x) => x,
-		None => panic!("Asset handle not registered: {}", std::any::type_name::<A>()),
-	};
-
-	registration.insert(loader);
-
-	drop(type_registry);
-
-	app
-}
-
 impl GenericMaterialSubAssetAppExt for App {
 	#[track_caller]
 	fn register_generic_material_sub_asset<A: Asset>(&mut self) -> &mut Self {
-		register_generic_material_sub_asset_internal::<A>(
-			self,
-			ReflectGenericMaterialSubAsset {
-				load: |processor, path| Box::new(processor.load_context.load::<A>(path)),
-			},
-		)
+		let mut type_registry = self.world().resource::<AppTypeRegistry>().write();
+		let registration = match type_registry.get_mut(TypeId::of::<Handle<A>>()) {
+			Some(x) => x,
+			None => panic!(
+				"Asset handle not registered: {}, did you forget to call `add_asset()` first?",
+				std::any::type_name::<A>()
+			),
+		};
+
+		registration.insert(ReflectGenericMaterialSubAsset {
+			load: |processor, path| Box::new(processor.load::<A>(path)),
+		});
+
+		drop(type_registry);
+
+		self
 	}
 
 	#[track_caller]
-	fn register_generic_material_sub_asset_image_settings_passthrough<A: Asset>(&mut self) -> &mut Self {
-		register_generic_material_sub_asset_internal::<A>(
-			self,
-			ReflectGenericMaterialSubAsset {
-				load: |processor, path| Box::new(processor.load_with_image_settings::<A>(path)),
-			},
-		)
+	fn insert_generic_material_asset_settings_modifier<S: Settings>(
+		&mut self,
+		target: AssetSettingsTarget<'static>,
+		modifier: impl Fn(&mut S) + Clone + Send + Sync + 'static,
+	) -> &mut Self {
+		self.world().resource::<GlobalAssetSettingsModifiers>().insert(target, modifier);
+		self
 	}
 }
 
@@ -126,11 +140,149 @@ pub fn relative_asset_path(relative_to: &AssetPath<'static>, path: &str) -> Resu
 	}
 }
 
-// TODO: This ignores meta files. Is there some way to check if a meta file is being used?
+/// A function that modifies a nested loader, expected to call `with_settings()`. This is like this instead of the modifier that `with_settings()` takes because of the generic in that function.
+///
+/// If the api that `with_settings()` calls was public, we would be able to use that instead, oh well!
+pub type AssetSettingsModifier = Arc<
+	dyn for<'ctx, 'builder> Fn(NestedLoader<'ctx, 'builder, StaticTyped, Deferred>) -> NestedLoader<'ctx, 'builder, StaticTyped, Deferred>
+		+ Send
+		+ Sync
+		+ 'static,
+>;
 
-/// Returns a function for setting an asset loader's settings to the supplied [`ImageLoaderSettings`].
-#[cfg(feature = "bevy_image")]
-pub fn set_image_loader_settings(settings: &ImageLoaderSettings) -> impl Fn(&mut ImageLoaderSettings) + 'static {
-	let settings = settings.clone();
-	move |s| *s = settings.clone()
+/// Asset settings modifiers can either target specific material's fields, or specific [material properties](crate::MaterialProperty).
+///
+/// NOTE: Currently, specific fields *within* material properties aren't supported for simplicity, if your use case requires this, make an issue!
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AssetSettingsTarget<'a> {
+	/// A field within a [`Material`] struct.
+	Field {
+		/// The type id of the material.
+		type_id: TypeId,
+		/// The field within the material.
+		field: &'a str,
+	},
+	/// A [`MaterialProperty`](crate::MaterialProperty). Contains the name of the property you want to target.
+	Property(&'a str),
+}
+impl<'a> AssetSettingsTarget<'a> {
+	/// Shorthand for
+	/// ```
+	/// # use bevy_materialize::load::asset::AssetSettingsTarget;
+	/// # use std::any::TypeId;
+	/// # type T = ();
+	/// AssetSettingsTarget::Field { type_id: TypeId::of::<T>(), field: "<field name>" }
+	/// # ;
+	/// ```
+	#[inline]
+	pub fn field<T: Asset>(field: &'a str) -> Self {
+		Self::Field {
+			type_id: TypeId::of::<T>(),
+			field,
+		}
+	}
+}
+
+/// Settings passed to a [`GenericMaterial`](crate::GenericMaterial) loader to modify sub-assets' settings.
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct AssetSettingsModifiers {
+	/// Maps a material's field or a material property to a function that modifies the asset settings when loading sub-assets from that field/property.
+	///
+	/// Use [`insert(...)`](Self::insert), [`replace(...)`](Self::replace) or [`with(...)`](Self::with) to modify this.
+	#[serde(skip)]
+	pub settings_map: HashMap<AssetSettingsTarget<'static>, AssetSettingsModifier>,
+}
+impl AssetSettingsModifiers {
+	/// Inserts a new settings modifier into the map. This function stacks, meaning the code
+	/// ```
+	/// # use bevy_materialize::{prelude::*, load::asset::AssetSettingsModifiers};
+	/// # use bevy::{prelude::*, image::{ImageLoaderSettings, ImageSampler}};
+	/// let mut modifiers = AssetSettingsModifiers::default();
+	/// modifiers.insert(AssetSettingsTarget::field::<StandardMaterial>("base_color_texture"), |settings: &mut ImageLoaderSettings| settings.sampler = ImageSampler::linear());
+	/// modifiers.insert(AssetSettingsTarget::field::<StandardMaterial>("base_color_texture"), |settings: &mut ImageLoaderSettings| settings.is_srgb = false);
+	/// ```
+	/// Will cause [`base_color_texture`](StandardMaterial::base_color_texture) to use both linear filtering *and* a linear color space.
+	///
+	/// If you want to fully *replace* the modifier, you should use [`replace(...)`](Self::replace).
+	pub fn insert<S: Settings>(&mut self, target: AssetSettingsTarget<'static>, modifier: impl Fn(&mut S) + Clone + Send + Sync + 'static) {
+		if let Some(previous_modifier) = self.settings_map.remove(&target) {
+			self.settings_map.insert(
+				target,
+				Arc::new(move |loader| {
+					let loader = previous_modifier(loader);
+					loader.with_settings(modifier.clone())
+				}),
+			);
+		} else {
+			self.replace(target, modifier);
+		}
+	}
+
+	/// [`insert(...)`](Self::insert) without generics. You should almost always use said function over this.
+	///
+	/// Like [`insert(...)`](Self::insert), this function does stack the modifier rather than overwrite.
+	pub fn insert_raw(&mut self, target: AssetSettingsTarget<'static>, modifier: AssetSettingsModifier) {
+		if let Some(previous_modifier) = self.settings_map.remove(&target) {
+			self.settings_map.insert(
+				target,
+				Arc::new(move |loader| {
+					// We don't call `insert_raw` from `insert` because this causes two Arc references per one of these functions, rather than just the one above thanks to the generics
+					let loader = previous_modifier(loader);
+					(modifier)(loader)
+				}),
+			);
+		} else {
+			self.settings_map.insert(target, modifier);
+		}
+	}
+
+	/// Shorthand for `settings_map.insert` and calling `with_settings`, but not called `insert` because the default behavior is to stack.
+	///
+	/// You usually don't need this, and should use [`insert(...)`](Self::insert) instead.
+	pub fn replace<S: Settings>(&mut self, target: AssetSettingsTarget<'static>, modifier: impl Fn(&mut S) + Clone + Send + Sync + 'static) {
+		self.settings_map
+			.insert(target, Arc::new(move |loader| loader.with_settings(modifier.clone())));
+	}
+
+	// We don't have a `replace_raw` function, since it would just be passing directly through to `settings_map.insert(...)` which is public api.
+
+	/// Calls [`insert(...)`](Self::insert) and returns `self` to provide a little builder syntax.
+	pub fn with<S: Settings>(mut self, target: AssetSettingsTarget<'static>, modifier: impl Fn(&mut S) + Clone + Send + Sync + 'static) -> Self {
+		self.insert(target, modifier);
+		self
+	}
+}
+
+/// Globally stored [`AssetSettingsModifiers`], this is used as a base when loading generic materials with the [`AssetSettingsModifiers`] provided per-asset-load inserted overtop.
+#[derive(Resource, Clone)]
+#[cfg_attr(not(feature = "bevy_pbr"), derive(Default))]
+pub struct GlobalAssetSettingsModifiers {
+	pub inner: Arc<RwLock<AssetSettingsModifiers>>,
+}
+impl GlobalAssetSettingsModifiers {
+	/// Calls the inner [`AssetSettingsModifiers::insert`] function. See docs for that.
+	pub fn insert<S: Settings>(&self, target: AssetSettingsTarget<'static>, modifier: impl Fn(&mut S) + Clone + Send + Sync + 'static) {
+		self.inner.write().unwrap().insert(target, modifier);
+	}
+}
+#[cfg(feature = "bevy_pbr")]
+impl Default for GlobalAssetSettingsModifiers {
+	fn default() -> Self {
+		let linear_modifier = |settings: &mut ImageLoaderSettings| settings.is_srgb = false;
+
+		#[rustfmt::skip]
+		let modifiers = AssetSettingsModifiers::default()
+			.with(AssetSettingsTarget::field::<StandardMaterial>("normal_map_texture"), linear_modifier)
+			.with(AssetSettingsTarget::field::<StandardMaterial>("occlusion_texture"), linear_modifier)
+			.with(AssetSettingsTarget::field::<StandardMaterial>("metallic_roughness_texture"), linear_modifier)
+			.with(AssetSettingsTarget::field::<StandardMaterial>("anisotropy_texture"), linear_modifier)
+			.with(AssetSettingsTarget::field::<StandardMaterial>("clearcoat_texture"), linear_modifier)
+			.with(AssetSettingsTarget::field::<StandardMaterial>("clearcoat_roughness_texture"), linear_modifier)
+			.with(AssetSettingsTarget::field::<StandardMaterial>("clearcoat_normal_texture"), linear_modifier)
+		;
+
+		Self {
+			inner: Arc::new(RwLock::new(modifiers)),
+		}
+	}
 }

--- a/src/load/error.rs
+++ b/src/load/error.rs
@@ -22,6 +22,8 @@ pub enum GenericMaterialLoadError {
 	WrongNumberEnumElements,
 	#[error("No property by the name of {0}")]
 	NoProperty(String),
+	#[error("No field by the name of {field_name} in type {type_name}")]
+	NoField { type_name: &'static str, field_name: String },
 	#[error("Type not registered: {0}")]
 	TypeNotRegistered(&'static str),
 	#[error("Property {0} found, but was not registered to any type. Use `App::register_material_property` to register it")]

--- a/src/load/error.rs
+++ b/src/load/error.rs
@@ -22,7 +22,7 @@ pub enum GenericMaterialLoadError {
 	WrongNumberEnumElements,
 	#[error("No property by the name of {0}")]
 	NoProperty(String),
-	#[error("No field by the name of {field_name} in type {type_name}")]
+	#[error("No field by the name of {field_name:?} in type {type_name}")]
 	NoField { type_name: &'static str, field_name: String },
 	#[error("Type not registered: {0}")]
 	TypeNotRegistered(&'static str),

--- a/src/load/inheritance.rs
+++ b/src/load/inheritance.rs
@@ -78,7 +78,15 @@ pub(super) async fn apply_inheritance<D: MaterialDeserializer, P: MaterialProces
 		} else {
 			match (&mut final_material.material, sub_material.material) {
 				(Some(final_material_mat), Some(sub_material_mat)) => {
-					loader.deserializer.merge_value(final_material_mat, sub_material_mat);
+					// This is a HashMap, we we have to manually merge it.
+					for (key, sub_material_value) in sub_material_mat {
+						match final_material_mat.get_mut(&key) {
+							Some(final_material_value) => loader.deserializer.merge_value(final_material_value, sub_material_value),
+							None => {
+								final_material_mat.insert(key, sub_material_value);
+							}
+						}
+					}
 				}
 				(None, Some(sub_material_mat)) => final_material.material = Some(sub_material_mat),
 				_ => {}

--- a/src/load/simple.rs
+++ b/src/load/simple.rs
@@ -10,9 +10,6 @@ use std::convert::Infallible;
 
 use crate::generic_material::GenericMaterial;
 
-#[cfg(feature = "bevy_image")]
-use super::asset::set_image_loader_settings;
-
 /// Loads a [`GenericMaterial`] directly from an image file. By default it loads a [`StandardMaterial`], putting the image into its `base_color_texture` field, and setting `perceptual_roughness` set to 1.
 #[derive(Debug, Clone)]
 pub struct SimpleGenericMaterialLoader {
@@ -39,8 +36,9 @@ impl AssetLoader for SimpleGenericMaterialLoader {
 			#[cfg(feature = "bevy_pbr")]
 			let path = load_context.asset_path().clone();
 
+			// TODO: Support asset settings modifiers.
 			#[cfg(feature = "bevy_pbr")]
-			let material = (self.material)(load_context.loader().with_settings(set_image_loader_settings(settings)).load(path));
+			let material = (self.material)(load_context.loader().load(path));
 
 			Ok(GenericMaterial {
 				#[cfg(feature = "bevy_pbr")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,6 +7,9 @@ pub use crate::{MaterializeAppExt, generic_material::ReflectGenericMaterial};
 pub use crate::{
 	MaterializePlugin,
 	generic_material::{GenericMaterial, GenericMaterial3d},
-	load::{asset::GenericMaterialSubAssetAppExt, deserializer::MaterialDeserializer},
+	load::{
+		asset::{AssetSettingsTarget, GenericMaterialSubAssetAppExt},
+		deserializer::MaterialDeserializer,
+	},
 	material_property::{MaterialProperty, MaterialPropertyAppExt},
 };


### PR DESCRIPTION
Closes #11 

This replaces the old system of just overriding `ImageLoaderSettings` with one that works with any settings, and is set on specific fields.

I went through quite the journey to get here:

The current built-in Bevy solution is to use a meta file for the image. These are very verbose, you have to specify the loader and *all* settings, you can't just set one! Writing one for each image is very annoying.
- You could have a pre-processing step to write these for you. Could be an external script, probably should use Bevy's asset processing somehow. The problem with this is that it still doesn't work by default.
- We could store settings inside of material files. You would put something like the following in your base material.
```toml
[settings.normal_map_texture]
is_srgb = false
```
A little better, still doesn't make it work by default.

I landed on hardcoded modifiers, essentially a map of `(material type, field name)` to settings modifier function, with global defaults that make `StandardMaterial` work correctly out of the box.

The biggest problem is my way was the fact that Bevy's deserialization processor (what we use for loading assets when encountering a `Handle<...>`) has no context for where it came from, it doesn't know what field it's deserializing, or what type that field belongs to.
I worked around this by reading a `HashMap<String, Value>` in the `material` field of material files instead of just a `Value`, and then individually deserializing each one using the key of the map as the field name, combining them into the final type.

There are still a few loose ends:
- SimpleGenericMaterialLoader doesn't respect these modifiers innately, when we add suffix-based PBR to this loader the API will probably make it quite easy though.
- Image-switching material animations don't respect them either. This is harder because of the deserialization processor limitations above, i can't think of a good workaround.

I'll be honest, i am not too happy with this solution, it feels like there must be something more elegant.

I do have one other idea (that i totally didn't come up with writing this just now): I'm pretty sure that everything that `ImageLoaderSettings` specifies can also just be changed after loading, when we *do* know which field is using which image.
I don't think it would be too unreasonable to have a system to automatically change the format of the relevant textures away from sRGB, testing out the implementation it's actually pretty easy.