### PR TITLE
Update bevy to 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "readme.md"
 categories = ["game-development"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
 	"bevy_asset",
 	"bevy_log",
 ] }
@@ -19,7 +19,7 @@ thiserror = "2"
 toml = { version = "0.9", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.18", features = ["bevy_winit", "png"] }
+bevy = { version = "0.19", features = ["bevy_winit", "png"] }
 smol = "2"
 
 [[example]]

--- a/src/color_space_fix.rs
+++ b/src/color_space_fix.rs
@@ -28,7 +28,7 @@ impl ColorSpaceFixPlugin {
 					$(if let Some(image_handle) = &material.$field {
 						if let Some(image) = images.get(image_handle) {
 							if image.texture_descriptor.format.is_srgb() {
-								if let Some(image) = images.get_mut(image_handle) {
+								if let Some(mut image) = images.get_mut(image_handle) {
 									image.texture_descriptor.format = image.texture_descriptor.format.remove_srgb_suffix();
 								}
 							}

--- a/src/erased_material.rs
+++ b/src/erased_material.rs
@@ -179,7 +179,7 @@ impl ErasedMaterialHandleVTable {
 				world.resource_scope(|world, mut assets: Mut<'_, Assets<M>>| {
 					let asset = assets.get_mut(id.typed_debug_checked());
 					let asset: Option<&mut dyn Reflect> = match asset {
-						Some(m) => Some(m),
+						Some(m) => Some(m.into_inner_untracked()),
 						None => None,
 					};
 

--- a/src/generic_material.rs
+++ b/src/generic_material.rs
@@ -16,12 +16,12 @@ use crate::{material_property::GetPropertyError, prelude::MaterialProperty};
 ///
 /// When removing or replacing this component, the inserted [`MeshMaterial3d`] will be removed.
 #[derive(Component, Reflect, Debug, Clone, PartialEq, Eq, Default, Deref, DerefMut)]
-#[cfg_attr(feature = "bevy_pbr", component(on_replace = Self::on_replace))]
+#[cfg_attr(feature = "bevy_pbr", component(on_discard = Self::on_discard))]
 #[reflect(Component, Default)]
 pub struct GenericMaterial3d(pub Handle<GenericMaterial>);
 impl GenericMaterial3d {
 	#[cfg(feature = "bevy_pbr")]
-	fn on_replace(mut world: DeferredWorld, ctx: HookContext) {
+	fn on_discard(mut world: DeferredWorld, ctx: HookContext) {
 		let generic_material_handle = &world.entity(ctx.entity).get::<Self>().unwrap().0;
 		let Some(generic_material) = world.resource::<Assets<GenericMaterial>>().get(generic_material_handle) else { return };
 		let material_handle = generic_material.handle.clone();

--- a/src/load/asset.rs
+++ b/src/load/asset.rs
@@ -97,6 +97,6 @@ pub fn relative_asset_path(relative_to: &AssetPath<'static>, path: &str) -> Resu
 
 		Ok(asset_path)
 	} else {
-		parent.resolve(path)
+		Ok(parent.resolve(&AssetPath::try_parse(path)?))
 	}
 }

--- a/src/load/mod.rs
+++ b/src/load/mod.rs
@@ -233,10 +233,10 @@ fn load_toml() {
 	let asset_server = app.world().resource::<AssetServer>();
 
 	smol::block_on(async {
-		asset_server.load_untyped_async("materials/animated.toml").await.unwrap();
+		asset_server.load_builder().load_untyped_async("materials/animated.toml").await.unwrap();
 		// Custom materials require special scaffolding in the associated example, and so the test is there.
-		asset_server.load_untyped_async("materials/example.material.toml").await.unwrap();
-		asset_server.load_untyped_async("materials/sub-material.toml").await.unwrap();
+		asset_server.load_builder().load_untyped_async("materials/example.material.toml").await.unwrap();
+		asset_server.load_builder().load_untyped_async("materials/sub-material.toml").await.unwrap();
 	});
 }
 
@@ -247,6 +247,6 @@ fn load_json() {
 	let asset_server = app.world().resource::<AssetServer>();
 
 	smol::block_on(async {
-		asset_server.load_untyped_async("materials/example.material.json").await.unwrap();
+		asset_server.load_builder().load_untyped_async("materials/example.material.json").await.unwrap();
 	});
 }


### PR DESCRIPTION
Hey there!

All I've done was go through and make the minimal necessary changes to make it compile on Bevy 0.19. Tests look to be passing, too (there are some ignored ones, but it looks like they're incomplete code snippets from the docs and probably weren't expected to work). 

Just wanted to draw your attention to one thing. [Here](https://github.com/shakesbeare/bevy_materialize/blob/307949df36eae91a5efbf1f167129cba0d5b9a9d/src/erased_material.rs#L182), I've just overridden the new `AssetMut` stuff and asked for a regular mutable reference. This won't work with the change detection that's been added, but likely has parity with how it already worked, if I understand correctly. Something to think about if you want to change eventually. 

Let me know if you need anything else from me. Seemed pretty straightforward!